### PR TITLE
Make chown conditional

### DIFF
--- a/rel/files/riak
+++ b/rel/files/riak
@@ -5,8 +5,10 @@ RELX_RIAK={{platform_bin_dir}}/riak
 export PID_DIR={{pid_dir}}
 export RUNNER_LOG_DIR={{platform_log_dir}}
 
-mkdir -p $PID_DIR
-chown riak:riak $PID_DIR
+if [ ! -d $PID_DIR ]; then
+    mkdir -p $PID_DIR
+    chown riak:riak $PID_DIR
+fi
 
 # cuttlefish should be doing this, but it doesn't:
 VMARGS_PATH=`ls -1 ${RUNNER_GEN_DIR}/generated.conf/vm.*.args 2>/dev/null | tail -1`


### PR DESCRIPTION
Requires sudo if pid dir has not been created - but prevents chown issues when sudo not used and pid has been created