### PR TITLE
Fix passing of empty string arg to `riak rpc` in `riak admin services`

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -789,7 +789,7 @@ case "$1" in
             echo "Lists the services available on the node. See also: wait-for-service"
             exit 1
         fi
-        rpc riak_core_node_watcher services
+        rpc_raw riak_core_node_watcher services
         ;;
 
     wait[_-]for[_-]service)


### PR DESCRIPTION
This should fix https://github.com/OpenRiak/riak/issues/8.